### PR TITLE
chore: lighten backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,21 @@
-# Build stage
-FROM eclipse-temurin:17-jdk-jammy AS build
-WORKDIR /app
-COPY gradlew .
-COPY gradle gradle
-COPY build.gradle .
-COPY settings.gradle .
-COPY src src
-RUN chmod +x ./gradlew
-RUN ./gradlew bootJar -x test
+# syntax=docker/dockerfile:1.7
 
-# Run stage (Optimized for Render / Docker Runtime)
-FROM eclipse-temurin:17-jre-jammy
+FROM amazoncorretto:17-alpine-jdk AS build
 WORKDIR /app
+
+COPY gradlew .
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+COPY src ./src
+
+RUN chmod +x ./gradlew && ./gradlew --no-daemon bootJar -x test
+
+FROM amazoncorretto:17-alpine
+WORKDIR /app
+
 COPY --from=build /app/build/libs/*.jar app.jar
 
 # Render/Fly/Railway may inject PORT; default to 8080 locally.
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java -Xmx512m -Dserver.port=${PORT:-8080} -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java -Xmx512m -Dserver.port=${PORT:-8080} -jar /app/app.jar"]


### PR DESCRIPTION
## Summary
- replace Temurin Jammy images with a simpler Amazon Corretto Alpine multi-stage setup
- keep the Dockerfile in a conventional Spring Boot build/runtime split
- scope the change to backend/Dockerfile only

## Verification
- `cd backend && ./gradlew bootJar -x test`

## Notes
- Docker build/run was not executed here because the local Docker daemon was unavailable in-session.